### PR TITLE
Typo fix in Authem documentation

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -76,7 +76,7 @@
             %p Then in your model:
             %pre
               %code
-                include Authem::user
+                include Authem::User
 
           %article
             %h4 Model Usage


### PR DESCRIPTION
Fix typo in `include Authem::User`

I sent you an email about this before I realized that the site was on Github so you can ignore the email.
